### PR TITLE
charset set to utf-8 for html

### DIFF
--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -47,6 +47,7 @@ class HtmlHeadMixin(object):
         return """
         <html>
         <head>
+            <meta charset=utf-8" />
             <title>{name} - Junit Test Report</title>
             <style type="text/css">
               {css}


### PR DESCRIPTION
special characters as chinese cant be shown properly in iframes. however ifame doesnt support meta setting specifications. 
so we have to set the charset in test report html files.