### PR TITLE
fix html head

### DIFF
--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -47,7 +47,7 @@ class HtmlHeadMixin(object):
         return """
         <html>
         <head>
-            <meta charset=utf-8" />
+            <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
             <title>{name} - Junit Test Report</title>
             <style type="text/css">
               {css}


### PR DESCRIPTION
部分不加http-equiv="Content-Type" content="text/html; 的显示中文有乱码